### PR TITLE
Add "feature" changelog label

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ CHANGELOG_LABELS = [
     "changelog/bugfix",
     "changelog/breaking",
     "changelog/enhancement",
+    "changelog/feature",
     "changelog/internal",
     "changelog/ignore",
 ]
@@ -19,6 +20,7 @@ CHANGELOG_LABELS = [
 CHANGELOG_CATEGORIES = {
     "changelog/breaking": "Breaking Changes",
     "changelog/enhancement": "Enhancements",
+    "changelog/feature": "Features",
     "changelog/bugfix": "Fixed",
     "changelog/internal": "Internal",
 }


### PR DESCRIPTION
The changelog/ci-labels github action has been failing when using the `changelog/feature` label on PRs in dbt-cloud. This PR adds that label here so that the job can find the matching label.

![Screen Shot 2021-07-09 at 11 20 29 AM](https://user-images.githubusercontent.com/3207842/125100958-ab1e9300-e0a7-11eb-9ad9-23c1cf5c29f6.png)
