### PR TITLE
update GITHUB_ACCESS_TOKEN to GITHUB_TOKEN as per Github CLI conventions and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 ## Required Dependencies
 
 [PyGithub](https://pypi.org/project/PyGithub/)
+
+### Setup
+
+`pip install -r requirements.txt`
+
+Create a Github personal access token and set in your environment
+`export GITHUB_TOKEN=<< github personal access token >>`

--- a/src/main.py
+++ b/src/main.py
@@ -138,7 +138,7 @@ def run_ci(args):
     """
     pr_number = int(args.ci_pr)
 
-    github_instance = Github(os.getenv("GITHUB_ACCESS_TOKEN"))
+    github_instance = Github(os.getenv("GITHUB_TOKEN"))
     repo = github_instance.get_repo(REPO_NAME)
 
     pull = repo.get_pull(pr_number)
@@ -180,7 +180,7 @@ def run_changelog_generation(args):
     """
     Main function for the changelog generation process.
     """
-    github_instance = Github(os.getenv("GITHUB_ACCESS_TOKEN"))
+    github_instance = Github(os.getenv("GITHUB_TOKEN"))
     repo = github_instance.get_repo(REPO_NAME)
 
     entries = _get_changelog_entries(repo, args.start_sha)


### PR DESCRIPTION
Following https://cli.github.com/manual/gh_help_environment use GITHUB_TOKEN env var rather than GITHUB_ACCESS_TOKEN