### PR TITLE
Add end-sha flag

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -159,15 +159,19 @@ def run_ci(args):
 def _get_changelog_entries(repo, start_sha, end_sha):
     entries = []
 
-    passed_end_sha = False
-    if not end_sha:
-        passed_end_sha = True
+    end_sha_found = False
+    commits = repo.get_commits()
 
-    for commit in repo.get_commits():
+    # If end_sha is not specified then use the first commit
+    if end_sha is None:
+        end_sha = commits[0].sha
+
+    for commit in commits:
         if commit.sha == end_sha:
-            passed_end_sha = True
+            end_sha_found = True
 
-        if not passed_end_sha:
+        # Do not include commits if the end sha has not been found yet
+        if not end_sha_found:
             continue
 
         if commit.sha == start_sha:


### PR DESCRIPTION
## Description
Adds a new flag --end-sha

Right now when we generate the single tenant changelog, we have to cram in a number of actions in between release events. One of those is generating the changelog because the script assumes that all commits after the start sha should be included in the changelog. This PR adds a new flag to also specify an end sha, allowing us to generate changelogs on slices of the repo that are not dependent on whether additional stuff has been merged.

The end result is that this removes the changelog generation as an action that has to happen in between PR merges. 

--end-sha is an optional argument and not providing it retains the previous behavior.

## With a start sha (using the current code)
```
❯ python3 src/main.py --start-sha a7b1141e7115f94e33297d2fb03d2af0276aa0b5

#### Internal

- SHP-186 | Add modal for missing Azure OAuth token on IDE startup
- Change pod image policies in devspace
- First stab at refactor
- k8s: only cache pod IP
```

## With a start sha (using the PR code)
```
❯ python3 src/main.py --start-sha a7b1141e7115f94e33297d2fb03d2af0276aa0b5

#### Internal

- SHP-186 | Add modal for missing Azure OAuth token on IDE startup
- Change pod image policies in devspace
- First stab at refactor
- k8s: only cache pod IP
```

## With an end sha (Using the PR code)
```
❯ python3 src/main.py --start-sha a7b1141e7115f94e33297d2fb03d2af0276aa0b5 --end-sha 0e72f971ac73036751b36df8d8de183676155dee

#### Internal

- First stab at refactor
- k8s: only cache pod IP
```

